### PR TITLE
Easier setup and dev server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,29 +8,18 @@ The react server proxies requests to the express server (see /client/package.jso
 
 ## Installation Instructions
 
-Inside the /client folder, run 
-
-```
-npm install
-```
-
-
-Inside the /server folder, run 
-
-```
-npm install
-```
+`npm run setup` to install both server and client applications dependencies.
 
 If running on cloud9, you must rename the .env.development.cloud9 as .env.development.  Note that you should not commit this file to github.  It should be disabled when deploying to a productoin environment 
 
-
 To run the application, you must start both the client and the server: 
 
+`npm run dev` to start both servers
+
+Or you may run the below script in separate terminals
 ```
 npm run server
 ```
-
-In a seperate terminal:
 
 ```
 npm run client

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "scripts": {
     "start": "cd server && npm install && node ./bin/www",
-    "server": "cd server && PORT=8081 node ./bin/www",
-    "client": "cd client && npm start",
+    "server": "PORT=8081 npm start --prefix server",
+    "client": "npm start --prefix client",
+    "dev": "npm run server & npm run client",
+    "setup": "npm install --prefix server && npm install --prefix client",
     "heroku-postbuild": "cd client && npm install --only=dev && npm install && npm run build",
     "test": "mocha"
   },


### PR DESCRIPTION
* Developer can simply run `npm run setup` to install dependencies and `npm run dev` to run dev server.