### PR TITLE
Skip DB_URI test on CI

### DIFF
--- a/server/routes/helpers/database_singleton.js
+++ b/server/routes/helpers/database_singleton.js
@@ -1,7 +1,10 @@
 var mongoose = require('mongoose');
 
-var DB_URI = process.env.DATABASE_URI || require('../../config/secret').DATABASE_URI; 
-
+if (process.env.CI === undefined) {
+  var DB_URI = process.env.DATABASE_URI || require('../../config/secret').DATABASE_URI;
+} else {
+  var DB_URI = process.env.DATABASE_URI;
+}
 
 var db;
 

--- a/server/test/database_singleton.js
+++ b/server/test/database_singleton.js
@@ -4,7 +4,7 @@ var mongoose = require('mongoose');
 var databaseModule = require('../routes/helpers/database_singleton'); 
 
 
-it('should have a DATABASE_URI defined', function(done) {
+(process.env.CI ? it.skip : it)('should have a DATABASE_URI defined', function(done) {
     databaseModule.DB_URI.should.not.equal(''); 
     done(); 
 });


### PR DESCRIPTION
* When pull request is made across fork, Travis do not allow encrypted environment variable for security reason and this is making test to fail when pull request is made across fork.
* However, this DB_URI test is still useful locally for initial setup.