### PR TITLE
Ignore server/node_module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+server/node_modules
 client/node_modules
 # testing
 client/coverage


### PR DESCRIPTION
* When moving file structure into separate client and server application, we forgot to add ignore `server/node_module`